### PR TITLE
Fix docline merge if there is no documentation

### DIFF
--- a/nedoc/docstring.py
+++ b/nedoc/docstring.py
@@ -61,6 +61,7 @@ def parse_docstring(
     if docstring is None:
         return ParsedDocString(None, None)
 
+    orig_docstring = docstring
     docstring = merge_first_line(docstring.strip())
 
     ds_style = STYLE_MAP.get(style)
@@ -74,14 +75,14 @@ def parse_docstring(
             description = description.lstrip()
         return ParsedDocString(docline, description)
 
-    dstr = docstring_parser.parse(docstring, ds_style)
+    dstr = docstring_parser.parse(orig_docstring, ds_style)
     subsections = [
         (m.args[0].replace("_", " ").capitalize(), m.description)
         for m in dstr.meta
         if len(m.args) == 1 and m.args[0] not in ("param", "returns", "raises")
     ]
     return ParsedDocString(
-        dstr.short_description,
+        docstring.split("\n", 1)[0],
         dstr.long_description,
         dstr.params,
         dstr.returns,

--- a/nedoc/markup/md.py
+++ b/nedoc/markup/md.py
@@ -70,8 +70,10 @@ class NedocRenderer(marko.HTMLRenderer):
                 if item is not None:
                     return self.render_intradoc_link(target=item, element=element)
 
-        logging.warning(f"Intradoc link `{original_link}` in {render_cname(self.unit.cname)} "
-                        "could not be resolved")
+        logging.warning(
+            f"Intradoc link `{original_link}` in {render_cname(self.unit.cname)} "
+            "could not be resolved"
+        )
 
         return super().render_link(element)
 
@@ -102,7 +104,7 @@ def get_intradoc_link(element: Link) -> Optional[str]:
 
 
 def convert_markdown_to_html(
-        ctx: GlobalContext, unit: Unit, text: Optional[str]
+    ctx: GlobalContext, unit: Unit, text: Optional[str]
 ) -> str:
     if text is None:
         return ""

--- a/tests/markup/test_markdown.py
+++ b/tests/markup/test_markdown.py
@@ -1,4 +1,5 @@
 from nedoc.config import DocstringStyle, Markup
+
 from ..utils.project_builder import ProjectBuilder, render_docline, render_docstring
 
 
@@ -346,7 +347,9 @@ def test_markdown_link_missing_parent(tmp_path):
 
 
 def test_markdown_in_argument_docstring(tmp_path, snapshot):
-    rendered = render_docstring(tmp_path, '''
+    rendered = render_docstring(
+        tmp_path,
+        '''
 def target(a: int):
     """
     Documentation.
@@ -356,12 +359,17 @@ def target(a: int):
 
 def bar():
     pass
-''', style=DocstringStyle.RST, markup=Markup.MARKDOWN)
+''',
+        style=DocstringStyle.RST,
+        markup=Markup.MARKDOWN,
+    )
     snapshot.assert_match(rendered, "expected.html")
 
 
 def test_markdown_in_docline(tmp_path, snapshot):
-    rendered = render_docline(tmp_path, '''
+    rendered = render_docline(
+        tmp_path,
+        '''
 def target(a: int):
     """
     Documentation with **bold text** and a [link](`.bar`).
@@ -369,7 +377,9 @@ def target(a: int):
 
 def bar():
     pass
-''', markup=Markup.MARKDOWN)
+''',
+        markup=Markup.MARKDOWN,
+    )
     snapshot.assert_match(rendered, "expected.html")
 
 

--- a/tests/test_docstring.py
+++ b/tests/test_docstring.py
@@ -3,7 +3,7 @@ import pytest
 from nedoc.config import DocstringStyle
 from nedoc.docstring import merge_first_line, parse_docstring
 
-from .utils.project_builder import render_docstring
+from .utils.project_builder import parse_unit_with_ctx, render_docstring
 
 
 def test_merge_first_list():
@@ -90,3 +90,39 @@ class target:
         copy_init_docstring=True,
     )
     snapshot.assert_match(rendered, "expected.html")
+
+
+def test_parse_docstring_parameters(tmp_path, snapshot):
+    ctx, unit = parse_unit_with_ctx(
+        tmp_path,
+        '''
+def target(self, a: int, b: int):
+    """
+    Some documentation.
+
+    :param a: first argument
+    :param b: second argument
+    """
+''',
+    )
+    docstring = ctx.parsed_docstring(unit)
+    assert len(docstring.params) == 2
+    assert docstring.params[0].arg_name == "a"
+    assert docstring.params[1].arg_name == "b"
+
+
+def test_parse_docstring_parameters_no_docline(tmp_path, snapshot):
+    ctx, unit = parse_unit_with_ctx(
+        tmp_path,
+        '''
+def target(self, a: int, b: int):
+    """
+    :param a: first argument
+    :param b: second argument
+    """
+''',
+    )
+    docstring = ctx.parsed_docstring(unit)
+    assert len(docstring.params) == 2
+    assert docstring.params[0].arg_name == "a"
+    assert docstring.params[1].arg_name == "b"


### PR DESCRIPTION
Docline merging (merging the first line of docstring) works incorrectly if there is no documentation at all (just e.g. RST parameter description).

For example, here:
```python
def target(a: int, b: int):
    """
    :param a: foo
    :param b: bar
    """
```
it merges RST to `:param a: foo :param b: bar`, which breaks it.

It doesn't seem to be that trivial to solve without changing the existing semantics of the first line merge.