### PR TITLE
Relax `pygments` dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ asttokens==2.0.5
 mako==1.1.6
 tqdm>=4.62,<5
 htmlmin==0.1.12
-pygments==2.11.2
+pygments>=2.11,<3
 docutils==0.18.1
 docstring-parser==0.13
 marko>=1.2,<2


### PR DESCRIPTION
It was conflicting with `mkdocs`, because it required a newer version of `pygments`.